### PR TITLE
(docs)fix: pass `customLogger` to `loadConfigFromFile`

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -390,7 +390,8 @@ async function loadConfigFromFile(
   configEnv: ConfigEnv,
   configFile?: string,
   configRoot: string = process.cwd(),
-  logLevel?: LogLevel
+  logLevel?: LogLevel,
+  customLogger?: Logger,
 ): Promise<{
   path: string
   config: UserConfig


### PR DESCRIPTION
Closes #168.